### PR TITLE
Fix Linking to a Session via URL Hash

### DIFF
--- a/src/templates/sessionsPageLayout.tsx
+++ b/src/templates/sessionsPageLayout.tsx
@@ -57,7 +57,7 @@ const SessionsPageLayout = (props: any) => {
                 session.scrollIntoView();
             }
         }
-    }, []);
+    }, [isLoadingFavoritedSessions, isLoadingSessionFilter]);
 
     useEffect((): void => {
         const viewFavorites: boolean = props.location && props.location.search ?


### PR DESCRIPTION
Fixes #72

This url should scroll down to the Lunch Session
https://deploy-preview-73--preview-cwitc.netlify.com/2019/sessions#lunch