### PR TITLE
Do not render 404 page during SSG

### DIFF
--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -13,7 +13,7 @@
         background-position: center bottom;
         background-size: cover;
         align-items: center;
-        height: 60vh;
+        flex: 0 0 60vh;
         min-height: 380px;
         margin-bottom: 3rem;
 

--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -1,0 +1,17 @@
+// set all generated container elements to full height
+html, body, #___gatsby, #gatsby-focus-wrapper, div[role="group"][tabindex] {
+    height: 100%;
+}
+
+#gatsby-focus-wrapper {
+    display: flex;
+    flex-direction: column;
+}
+
+body {
+    margin: 0px;
+}
+
+.main {
+    flex-grow: 1;
+}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -8,6 +8,7 @@ import { trimChar } from './../services/text-helper';
 
 // Imports Bootstrap
 import './_vars.scss';
+import './layout.scss';
 
 // Polyfills
 import 'core-js/es6/number';
@@ -98,7 +99,7 @@ const Layout = ({ isHomePage = false, className, path, children }: Props) => (
                         <link rel="canonical" href={ canonicalUrl } />
                     </Helmet>
                     <Header useHero={ isHomePage }/>
-                    <div className={ className }>
+                    <div className={ `main ${ className }` }>
                         { children }
                     </div>
                     <Footer { ...footerConfig }/>

--- a/src/components/not-found/notFound.tsx
+++ b/src/components/not-found/notFound.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
-import Icon from '../icon/icon';
+import Icon from '../icon/icon'
+
+const browser = typeof window !== 'undefined' && window;;
 
 const NotFound = () => (
-    <div className="container mt-4">
+    browser ?
+    <div className="404-container container mt-4">
         <div className="row">
             <div className="col d-flex flex-column align-items-center">
                 <Icon name="zap" />
@@ -10,7 +13,7 @@ const NotFound = () => (
                 <p>This page doesn't exist</p>
             </div>
         </div>
-    </div>
+    </div> : null
 );
 
 NotFound.defaultProps = {


### PR DESCRIPTION
During site generation, the client app page was rendering the 404 page because there is no current route. Before rendering the 404 page, check to make sure the current environment is the browser.

This created some jumping, so I've made the body minimum height to be the size of the viewport, so the footer doesnt jump down after content loads.